### PR TITLE
example.c: FPPTAG_IGNOREVERSION should be FPPTAG_SHOWVERSION

### DIFF
--- a/src/example.c
+++ b/src/example.c
@@ -310,7 +310,7 @@ int SetOptions(int argc, char **argv, struct fppTag **tagptr)
         break;
 
       case 'V':			      /* do not output version */
-	(*tagptr)->tag = FPPTAG_IGNOREVERSION;
+	(*tagptr)->tag = FPPTAG_SHOWVERSION;
 	(*tagptr)->data= (void *)FALSE;
 	(*tagptr)++;
 	break;


### PR DESCRIPTION
This fixes a bug introduced in commit eba2f6fc5394e024294461d430593524b8e0ebd8 which had renamed the macro.